### PR TITLE
Use "overwrite" action when patching models

### DIFF
--- a/yaml2workflow/parser/model.py
+++ b/yaml2workflow/parser/model.py
@@ -30,7 +30,7 @@ def _add_new_model_version(stub: service_pb2_grpc.V2Stub, old_api_model: resourc
   response = stub.PatchModels(
     service_pb2.PatchModelsRequest(
       models=[new_api_model],
-      action="merge"
+      action="overwrite"
     ),
     metadata=metadata)
   assert response.status.code == status_code_pb2.SUCCESS, f'Invalid response {response}'


### PR DESCRIPTION
The YAML file contains a complete description of the model so overwrite instead of merging with existing model version when patching.